### PR TITLE
QoL

### DIFF
--- a/registrytweaks.md
+++ b/registrytweaks.md
@@ -59,8 +59,8 @@
 - Disable enable peek
 - Disable save taskbar thumbnail previews
 - Enable show thumbnails instead of icons
-- Disable show translucent selection rectangle
-- Disable show window contents while dragging
+- Enable show translucent selection rectangle
+- Enable show window contents while dragging
 - Enable smooth edges of screen fonts
 - Disable use drop shadows for icon labels on the desktop
 - Adjust for best performance of programs
@@ -171,3 +171,16 @@
 - Remove resume from taskbar
 - Disable show me suggested apps in share
 - Increase wallpaper quality
+- Disable automatic troubleshooting
+- Disable write with fingertip
+- Disable share window from taskbar
+- Disable desktop preview
+- Disable small taskbar buttons
+- Disable touch keyboard
+- Disable auto correction
+- Disable touch indicator
+- Disable keyboard shortcut for contrast themes
+- Disable notification for sticky, filter or toggle keys
+- Disable USB error notifications
+- Disable delivery optimization
+- Disable XBOX mode

--- a/src/RegTweaks.txt
+++ b/src/RegTweaks.txt
@@ -366,7 +366,7 @@ Windows Registry Editor Version 5.00
 "VisualFXSetting"=dword:3
 
 [HKEY_CURRENT_USER\Control Panel\Desktop]
-"UserPreferencesMask"=hex(2):90,12,03,80,10,00,00,00
+"UserPreferencesMask"=hex(2):90,12,02,80,10,01,00,00
 
 ; Disable animate windows when minimizing and maximizing
 [HKEY_CURRENT_USER\Control Panel\Desktop\WindowMetrics]
@@ -392,13 +392,13 @@ Windows Registry Editor Version 5.00
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
 "IconsOnly"=dword:0
 
-; Disable show translucent selection rectangle
+; Enable show translucent selection rectangle
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
-"ListviewAlphaSelect"=dword:0
+"ListviewAlphaSelect"=dword:1
 
-; Disable show window contents while dragging
+; Enable show window contents while dragging
 [HKEY_CURRENT_USER\Control Panel\Desktop]
-"DragFullWindows"="0"
+"DragFullWindows"="1"
 
 ; Enable smooth edges of screen fonts
 [HKEY_CURRENT_USER\Control Panel\Desktop]
@@ -801,7 +801,10 @@ Windows Registry Editor Version 5.00
 
 ; Disable language bar
 [HKEY_CURRENT_USER\SOFTWARE\Microsoft\CTF\LangBar]
+"ExtraIconsOnMinimized"=dword:00000000
+"Label"=dword:00000000
 "ShowStatus"=dword:00000003
+"Transparency"=dword:000000ff
 
 ; Disable lock screen image
 [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System]
@@ -1095,3 +1098,64 @@ Windows Registry Editor Version 5.00
 ; Increase wallpaper quality
 [HKEY_CURRENT_USER\Control Panel\Desktop]
 "JPEGImportQuality"=dword:00000064
+
+; Disable automatic troubleshooting
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\WindowsMitigation]
+"UserPreference"=dword:00000001
+
+; Disable write with fingertip
+[HKEY_CURRENT_USER\Software\Microsoft\TabletTip\EmbeddedInkControl]
+"EnableInkingWithTouch"=dword:00000000
+
+; Disable share window from taskbar
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
+"TaskbarSn"=dword:00000000
+
+; Disable desktop preview
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
+"TaskbarSd"=dword:00000000
+
+; Disable small taskbar buttons
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
+"IconSizePreference"=dword:00000001
+
+; Disable touch keyboard
+[HKEY_CURRENT_USER\Software\Microsoft\TabletTip\1.7]
+"EnableAutoShiftEngage"=dword:00000000
+"EnableDoubleTapSpace"=dword:00000000
+"EnableKeyAudioFeedback"=dword:00000000
+"TouchKeyboardTapInvoke"=dword:00000000
+"TipbandDesiredVisibility"=dword:00000000
+
+[HKEY_CURRENT_USER\Software\Microsoft\input\Settings]
+"IsVoiceTypingKeyEnabled"=dword:00000000
+
+; Disable auto correction
+[HKEY_CURRENT_USER\Software\Microsoft\TabletTip\1.7]
+"EnableAutocorrection"=dword:00000000
+
+; Disable touch indicator
+[HKEY_CURRENT_USER\Control Panel\Cursors]
+"ContactVisualization"=dword:00000000
+"GestureVisualization"=dword:00000018
+
+; Disable keyboard shortcut for contrast themes
+[HKEY_CURRENT_USER\Control Panel\Accessibility\HighContrast]
+"Flags"="4128"
+
+; Disable notification for sticky, filter or toggle keys
+[HKEY_CURRENT_USER\Control Panel\Accessibility]
+"Sound on Activation"=dword:00000000
+"Warning Sounds"=dword:00000000
+
+; Disable USB error notifications
+[HKEY_CURRENT_USER\Software\Microsoft\Shell\USB]
+"NotifyOnUsbErrors"=dword:00000000
+
+; Disable delivery optimization
+[HKEY_USERS\S-1-5-20\Software\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Settings]
+"DownloadMode"=dword:00000000
+
+; Disable XBOX mode
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\GamingConfiguration]
+"GamingHomeApp"=""

--- a/src/Restore.ps1
+++ b/src/Restore.ps1
@@ -1995,7 +1995,10 @@ Windows Registry Editor Version 5.00
 "Enabled"=-
 
 [HKEY_CURRENT_USER\SOFTWARE\Microsoft\CTF\LangBar]
+"ExtraIconsOnMinimized"=-
+"Label"=-
 "ShowStatus"=-
+"Transparency"=-
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System]
 "DisableLogonBackgroundImage"=-

--- a/src/Restore.ps1
+++ b/src/Restore.ps1
@@ -2187,7 +2187,54 @@ Windows Registry Editor Version 5.00
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\CDP]
 "EnablePromotionalAppsForShare"=-
 
-[-HKEY_CURRENT_USER\Control Panel\Desktop\JPEGImportQuality]
+[HKEY_CURRENT_USER\Control Panel\Desktop]
+"JPEGImportQuality"=-
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\WindowsMitigation]
+"UserPreference"=-
+
+[HKEY_CURRENT_USER\Software\Microsoft\TabletTip\EmbeddedInkControl]
+"EnableInkingWithTouch"=-
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
+"TaskbarSn"=-
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
+"TaskbarSd"=-
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
+"IconSizePreference"=-
+
+[HKEY_CURRENT_USER\Software\Microsoft\TabletTip\1.7]
+"EnableAutocorrection"=-
+"EnableAutoShiftEngage"=-
+"EnableDoubleTapSpace"=-
+"EnableKeyAudioFeedback"=-
+"TouchKeyboardTapInvoke"=-
+"TipbandDesiredVisibility"=-
+
+[HKEY_CURRENT_USER\Software\Microsoft\input\Settings]
+"IsVoiceTypingKeyEnabled"=-
+
+[HKEY_CURRENT_USER\Control Panel\Cursors]
+"ContactVisualization"=-
+"GestureVisualization"=-
+
+[HKEY_CURRENT_USER\Control Panel\Accessibility\HighContrast]
+"Flags"=-
+
+[HKEY_CURRENT_USER\Control Panel\Accessibility]
+"Sound on Activation"=-
+"Warning Sounds"=-
+
+[HKEY_CURRENT_USER\Software\Microsoft\Shell\USB]
+"NotifyOnUsbErrors"=-
+
+[HKEY_USERS\S-1-5-20\Software\Microsoft\Windows\CurrentVersion\DeliveryOptimization\Settings]
+"DownloadMode"=-
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\GamingConfiguration]
+"GamingHomeApp"=-
 '@
 
     Add-Content -Path $file.FullName -Value $regContent -Force


### PR DESCRIPTION
i updated the reg file to now cover pretty much all available options in the immersive control panel
testing on my vm (win11 pro 26200.8737), these options were all on by default

reg tweaks added:

- Disable automatic troubleshooting
- Disable write with fingertip
- Disable share window from taskbar
- Disable desktop preview
- Disable small taskbar buttons
- Disable touch keyboard
- Disable auto correction
- Disable touch indicator
- Disable keyboard shortcut for contrast themes
- Disable notification for sticky, filter or toggle keys
- Disable USB error notifications
- Disable delivery optimization
- Disable XBOX mode

why?:

fairly self-explanatory, most of these are completely useless
for the `Disable USB error notifications`, this could be useful, but theres no point if notis are globally disabled
as for the `Disable delivery optimization`, i know this tweak is already in the disable updates option, however i think this should be off no matter what and by putting it in regtweaks it assures that users who leave updates enabled still have this disabled

i also updated some of the already existing tweaks such as:

- Disable language bar
- Set appearance options to custom
- Disable show translucent selection rectangle
- Disable show window contents while dragging

why?:

the language bar was missing some options to fully disable everything
as for the appearance options, the 00 > 01 turns on `use the desktop language bar when its available`, this combined with all the extra language bar settings turned off will make it completely hidden from the taskbar at all times (you might have seen the convo with knockly on dc about this issue)
the 03 > 02 turns off `hide pointer while typing` as theres prob no use case for this unless you maybe use office or something
the `show translucent selection rectangle` always bothered me, because if you disable this, it will still actually show up in the file explorer when you select something

<img width="1221" height="749" alt="image" src="https://github.com/user-attachments/assets/0b1015e0-6528-4ca4-882d-bedc0560b414" />

so might as well use it on the desktop too to not have this weird mismatch
disabling `show window contents while dragging` is just insanely ugly tbh
also makes it harder to line up windows with each other
with these changes the visual settings will look like this

<img width="413" height="597" alt="image" src="https://github.com/user-attachments/assets/b540ae4c-9ecd-429c-b388-ae7579c10f96" />

which is pretty much the bare minimum to not make windows look like shit, while still keeping all the settings that slow navigation down disabled

something interesting i found is that:

`[HKEY_CURRENT_USER\Control Panel\Accessibility]`
`"Sound on Activation"=dword:00000000`
`"Warning Sounds"=dword:00000000`

will actually control 2 different settings together
this:

<img width="952" height="197" alt="Screenshot 2026-07-12 193024" src="https://github.com/user-attachments/assets/2a9452d1-3ded-4821-b0c5-0963eefffb7a" />

and this:

<img width="927" height="168" alt="Screenshot 2026-07-12 193048" src="https://github.com/user-attachments/assets/7b509af0-8dfd-4184-a030-730d01485052" />
