### PR TITLE
2 new tweaks and some updates

### DIFF
--- a/registrytweaks.md
+++ b/registrytweaks.md
@@ -6,7 +6,7 @@
 - Disable storage sense
 - Leftmost taskbar
 - Enable action center
-- Disable snap layout
+- Disable snap assist and layout
 - Remove gallery shortcut from file explorer
 - Remove home shortcut from file explorer
 - Open file explorer to this PC
@@ -184,3 +184,5 @@
 - Disable USB error notifications
 - Disable delivery optimization
 - Disable XBOX mode
+- Enable last open window in taskbar
+- Hide removable drives from navigation pane

--- a/src/RegTweaks.txt
+++ b/src/RegTweaks.txt
@@ -51,9 +51,8 @@ Windows Registry Editor Version 5.00
 [HKEY_CURRENT_USER\SOFTWARE\Policies\Microsoft\Windows\Explorer]
 "DisableNotificationCenter"=-
 
-; Disable snap layout
+; Disable snap assist and layout
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
-"DITest"=dword:00000000
 "EnableSnapAssistFlyout"=dword:00000000
 "EnableSnapBar"=dword:00000000
 "EnableTaskGroups"=dword:00000000
@@ -455,6 +454,9 @@ Windows Registry Editor Version 5.00
 "VKToggleBroadcast"=dword:00000000
 "VKMToggleBroadcast"=dword:00000000
 "MicrophoneCaptureEnabled"=dword:00000000
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\GameDVR]
+"AllowGameDVR"=dword:00000000
 
 ; Privacy deny location
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\location]
@@ -1159,3 +1161,10 @@ Windows Registry Editor Version 5.00
 ; Disable XBOX mode
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\GamingConfiguration]
 "GamingHomeApp"=""
+
+; Enable last open window in taskbar
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
+"LastActiveClick"=dword:00000001
+
+; Hide removable drives from navigation pane
+[-HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\DelegateFolders\{F5FB2C77-0E2F-4A16-A381-3E560C68BC83}]

--- a/src/Restore.ps1
+++ b/src/Restore.ps1
@@ -1699,6 +1699,9 @@ Windows Registry Editor Version 5.00
 "SystemAudioGain"=-
 "MicrophoneGain"=-
 
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\GameDVR]
+"AllowGameDVR"=-
+
 [HKEY_CURRENT_USER\Software\Microsoft\GameBar]
 "UseNexusForGameBarEnabled"=-
 
@@ -2139,7 +2142,6 @@ Windows Registry Editor Version 5.00
 "SubscribedContentEnabled"=-
 
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
-"DITest"=-
 "EnableSnapAssistFlyout"=-
 "EnableSnapBar"=-
 "EnableTaskGroups"=-
@@ -2238,6 +2240,12 @@ Windows Registry Editor Version 5.00
 
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\GamingConfiguration]
 "GamingHomeApp"=-
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
+"LastActiveClick"=-
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\DelegateFolders\{F5FB2C77-0E2F-4A16-A381-3E560C68BC83}]
+@="Removable Drives"
 '@
 
     Add-Content -Path $file.FullName -Value $regContent -Force
@@ -2253,7 +2261,9 @@ Windows Registry Editor Version 5.00
 
   if ($checkbox6.Checked) {
     Write-Status -Message 'Downloading XBOX Game Repair Tool...' -Type Output
-    #remove gamebar popup block
+    #remove recording policy
+    Remove-ItemProperty 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\GameDVR' 'AllowGameDVR' -force -ea 0
+	#remove gamebar popup block
     Set-ItemProperty 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\GameDVR' 'AppCaptureEnabled' 1 -type dword -force -ea 0
     Set-ItemProperty 'HKCU:\System\GameConfigStore' 'GameDVR_Enabled' 1 -type dword -force -ea 0
     'ms-gamebar', 'ms-gamebarservices', 'ms-gamingoverlay' | ForEach-Object {


### PR DESCRIPTION
- added `Enable last open window in taskbar` to reg tweaks
  - by default when having multiple windows of the same application open, clicking on the icon in the taskbar wont do anything. with this tweak, clicking on the icon in the taskbar will open the last opened window and clicking again will open the one before that, and so on.

https://github.com/user-attachments/assets/778e73a5-19fe-409f-a36c-c1b2f6532629

- added `Hide removable drives from navigation pane` to reg tweaks
  - for some reason when plugging in any removable drive, it will show up in the navigation pane next to `This PC`. this tweak prevents that and makes it so that theyre only visible on the actual drives list (this only affects removable drives)
 
before:
<img width="1219" height="745" alt="before" src="https://github.com/user-attachments/assets/9399fa41-6f8b-4ee3-9225-e51525368d46" />
after:
<img width="1221" height="747" alt="after" src="https://github.com/user-attachments/assets/b7b89165-67c3-498f-bb6c-ab3ca1059284" />
since the file explorer (ideally) opens to `This PC` anyways, i dont see any reason for them to have additional shortcuts.

- added policy to fully disable game bar recording

before:
<img width="875" height="803" alt="Screenshot 2026-07-14 175351" src="https://github.com/user-attachments/assets/bfb32927-a5ef-4f50-a9a7-2e6533792393" />
after:
<img width="879" height="370" alt="Screenshot 2026-07-14 175329" src="https://github.com/user-attachments/assets/b9cacd36-8866-474c-89b8-3c24883f4c89" />
this policy is removed in both the `Revert Registry Tweaks` and `Repair XBOX Apps` options so that anyone who wants to actually use this feature doesnt run into any issues.

- removed the reg key for `When I drag a window, let me snap it without dragging all the way to the screen edge` since this does kinda help, although the difference is very small. i also updated the name for the snap tweak to make it more accurate.