### PR TITLE
add disable lock screen tweak

### DIFF
--- a/registrytweaks.md
+++ b/registrytweaks.md
@@ -186,3 +186,4 @@
 - Disable Xbox mode
 - Enable last open window in taskbar
 - Hide removable drives from navigation pane
+- Disable lock screen

--- a/src/RegTweaks.txt
+++ b/src/RegTweaks.txt
@@ -1168,3 +1168,7 @@ Windows Registry Editor Version 5.00
 
 ; Hide removable drives from navigation pane
 [-HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\DelegateFolders\{F5FB2C77-0E2F-4A16-A381-3E560C68BC83}]
+
+; Disable lock screen
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Personalization]
+"NoLockScreen"=dword:00000001

--- a/src/Restore.ps1
+++ b/src/Restore.ps1
@@ -2246,6 +2246,9 @@ Windows Registry Editor Version 5.00
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Desktop\NameSpace\DelegateFolders\{F5FB2C77-0E2F-4A16-A381-3E560C68BC83}]
 @="Removable Drives"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Personalization]
+"NoLockScreen"=-
 '@
 
     Add-Content -Path $file.FullName -Value $regContent -Force


### PR DESCRIPTION
skips the lock screen and puts you directly into the sign-in screen

before:
<img width="1020" height="767" alt="Screenshot 2026-07-31 215056" src="https://github.com/user-attachments/assets/0d397a5f-a99c-4d12-ba43-7cdbfe87b0eb" />

after:
<img width="1021" height="767" alt="Screenshot 2026-07-31 215219" src="https://github.com/user-attachments/assets/b74c0679-d2de-45fe-867c-be009dd6e74d" />
