### PR TITLE
Restrict launcher script resolution to the release directory

### DIFF
--- a/src/ZOICWARE.ps1
+++ b/src/ZOICWARE.ps1
@@ -289,9 +289,6 @@ if (!$offlineMode -and !$dontCheck4Updates) {
                         #rename old folder and pack
                         Rename-Item $folder -NewName 'OLD' -Force
                         Rename-Item $pack -NewName 'zoicwareOLD' -Force
-                        #clear cached location
-                        Remove-Item "$env:USERPROFILE\zLocation.tmp" -Force -ErrorAction SilentlyContinue
-                        New-Item "$env:USERPROFILE\zLocation.tmp" -Value "$env:USERPROFILE\Desktop\zoicwareOS$latestver\zoicwareOS\_FOLDERMUSTBEONCDRIVE\ZOICWARE.ps1" -Force | Out-Null
                         #start zoicware
                         Unblock-File "$env:USERPROFILE\Desktop\zoicwareOS$latestver\zoicwareOS\RUN ZOICWARE.exe"
                         Start-Process "$env:USERPROFILE\Desktop\zoicwareOS$latestver\zoicwareOS\RUN ZOICWARE.exe"

--- a/src/ZoicwareLauncher.cs
+++ b/src/ZoicwareLauncher.cs
@@ -6,18 +6,16 @@ namespace ZoicwareLauncher
 {
     class Program
     {
-        static readonly string LocationCache = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            "zLocation.tmp"
-        );
-
         static int Main(string[] args)
         {
-            string scriptPath = ResolveScriptPath();
+            string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            string scriptPath = ResolveScriptPath(baseDirectory);
 
             if (scriptPath == null)
             {
-                Console.Error.WriteLine("ERROR: ZOICWARE.ps1 not found.");
+                Console.Error.WriteLine("ERROR: ZOICWARE.ps1 was not found at the expected release path:");
+                Console.Error.WriteLine(GetExpectedScriptPath(baseDirectory));
+                Console.Error.WriteLine("Extract the complete zoicwareOS release and keep the launcher beside _FOLDERMUSTBEONCDRIVE.");
                 Console.Write("Press any key to exit...");
                 Console.ReadKey(true);
                 return 1;
@@ -26,68 +24,15 @@ namespace ZoicwareLauncher
             return LaunchScript(scriptPath);
         }
 
-        static string ResolveScriptPath()
+        internal static string ResolveScriptPath(string baseDirectory)
         {
-            //check for cached path
-            if (File.Exists(LocationCache))
-            {
-                string cached = File.ReadAllText(LocationCache).Trim();
-                if (File.Exists(cached))
-                {
-                    //Console.WriteLine("Using cached path: " + cached);
-                    return cached;
-                }
-                //delete cached file that has old path
-                try { File.Delete(LocationCache); } catch { }
-                //Console.WriteLine("Cached path invalid, searching...");
-            }
-
-            //check relative to the exe's own location first
-            string exeDir = AppDomain.CurrentDomain.BaseDirectory;
-            string relative = Path.Combine(exeDir, "_FOLDERMUSTBEONCDRIVE", "ZOICWARE.ps1");
-            if (File.Exists(relative))
-            {
-                CacheAndReturn(relative);
-                return relative;
-            }
-
-            //recursive search across all fixed drives
-            foreach (DriveInfo drive in DriveInfo.GetDrives())
-            {
-                if (drive.DriveType != DriveType.Fixed) continue;
-                string found = RecursiveSearch(drive.RootDirectory.FullName, "ZOICWARE.ps1");
-                if (found != null)
-                {
-                    CacheAndReturn(found);
-                    return found;
-                }
-            }
-
-            return null;
+            string scriptPath = GetExpectedScriptPath(baseDirectory);
+            return File.Exists(scriptPath) ? scriptPath : null;
         }
 
-
-        static string RecursiveSearch(string root, string fileName)
+        internal static string GetExpectedScriptPath(string baseDirectory)
         {
-            try
-            {
-                foreach (string file in Directory.EnumerateFiles(root, fileName,
-                    SearchOption.AllDirectories))
-                {
-                    // Skip recycle bin entries
-                    if (file.IndexOf("$Recycle.Bin", StringComparison.OrdinalIgnoreCase) >= 0)
-                        continue;
-                    return file;
-                }
-            }
-            catch { }
-            return null;
-        }
-
-        static void CacheAndReturn(string path)
-        {
-            try { File.WriteAllText(LocationCache, path); }
-            catch { /* ignore if cache write fails */ }
+            return Path.Combine(baseDirectory, "_FOLDERMUSTBEONCDRIVE", "ZOICWARE.ps1");
         }
 
         static int LaunchScript(string scriptPath)

--- a/tests/ZoicwareLauncherTests.cs
+++ b/tests/ZoicwareLauncherTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+
+namespace ZoicwareLauncher
+{
+    class LauncherResolverTests
+    {
+        static int failures;
+
+        static int Main()
+        {
+            string tempRoot = Path.Combine(
+                Path.GetTempPath(),
+                "ZoicwareLauncherTests-" + Guid.NewGuid().ToString("N")
+            );
+
+            try
+            {
+                string adjacentDirectory = Path.Combine(tempRoot, "adjacent release");
+                string adjacentScript = Program.GetExpectedScriptPath(adjacentDirectory);
+                WriteTestScript(adjacentScript);
+
+                AssertPath(
+                    adjacentScript,
+                    Program.ResolveScriptPath(adjacentDirectory),
+                    "resolves the script in the adjacent release directory"
+                );
+
+                string isolatedDirectory = Path.Combine(tempRoot, "missing");
+                string offTreeScript = Path.Combine(tempRoot, "elsewhere", "ZOICWARE.ps1");
+                Directory.CreateDirectory(isolatedDirectory);
+                WriteTestScript(offTreeScript);
+
+                AssertPath(
+                    null,
+                    Program.ResolveScriptPath(isolatedDirectory),
+                    "does not search outside the adjacent release directory"
+                );
+
+                File.Delete(adjacentScript);
+
+                AssertPath(
+                    null,
+                    Program.ResolveScriptPath(adjacentDirectory),
+                    "does not retain a cached path after the adjacent script is removed"
+                );
+            }
+            catch (Exception exception)
+            {
+                Fail("Unexpected exception: " + exception);
+            }
+            finally
+            {
+                try
+                {
+                    if (Directory.Exists(tempRoot))
+                        Directory.Delete(tempRoot, true);
+                }
+                catch (Exception exception)
+                {
+                    Fail("Could not remove temporary test directory: " + exception.Message);
+                }
+            }
+
+            if (failures == 0)
+            {
+                Console.WriteLine("All launcher resolver tests passed.");
+                return 0;
+            }
+
+            Console.Error.WriteLine(failures + " launcher resolver test(s) failed.");
+            return 1;
+        }
+
+        static void WriteTestScript(string path)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            File.WriteAllText(path, "# synthetic test script");
+        }
+
+        static void AssertPath(string expected, string actual, string description)
+        {
+            bool pathsMatch = expected == null
+                ? actual == null
+                : string.Equals(expected, actual, StringComparison.OrdinalIgnoreCase);
+
+            if (pathsMatch)
+                return;
+
+            Fail(description + ": expected '" + (expected ?? "<null>")
+                + "', got '" + (actual ?? "<null>") + "'.");
+        }
+
+        static void Fail(string message)
+        {
+            failures++;
+            Console.Error.WriteLine("FAIL: " + message);
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Resolve only `<launcher directory>/_FOLDERMUSTBEONCDRIVE/ZOICWARE.ps1`.
- Remove the user-profile location cache and fixed-drive recursive search.
- Stop the updater recreating the now-unused `zLocation.tmp` file.
- Add dependency-free resolver regression tests.

## Why

The launcher runs the selected PowerShell script after requesting elevation. The previous cache and first-match drive search could select a stale, unrelated or deliberately planted same-named script, while also scanning fixed drives. The release and updater already place the intended script beside the launcher in a fixed subdirectory.

## User impact

Complete release layouts behave as before. Incomplete or misplaced layouts now report the exact expected path, off-tree scripts are ignored, and updates no longer leave a location-cache artefact.

## Validation

- Compiled the production C# source with the repository manifest using .NET Framework 4.x `csc.exe /warn:4`.
- Compiled and ran the dependency-free resolver tests.
- Parsed `src/ZOICWARE.ps1` with PowerShell 7 and Windows PowerShell 5.1: zero errors.
- Ran the CRLF-aware Git diff check.

The production executable was not run, so this did not trigger UAC. A disposable-VM smoke test of the packaged release and updater remains appropriate before release.
