### PR TITLE
rename shortcut to separate it from others

### DIFF
--- a/src/zFunctions.psm1
+++ b/src/zFunctions.psm1
@@ -8848,7 +8848,7 @@ explorer ""$env:APPDATA\Microsoft\Windows\Start Menu\Programs"";explorer ""$env:
       $file = New-Item "$env:ProgramData\SilentStartMenuDir.ps1" -Value $psScript -Force
 
       $WshShell = New-Object -comObject WScript.Shell
-      $Shortcut = $WshShell.CreateShortcut("$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Shortcuts.lnk")
+      $Shortcut = $WshShell.CreateShortcut("$env:ProgramData\Microsoft\Windows\Start Menu\Programs\zShortcuts.lnk")
       $Shortcut.TargetPath = 'conhost.exe'
       $Shortcut.Arguments = "--headless powershell.exe -ep bypass -f `"$($file.FullName)`""
       $Shortcut.IconLocation = '%SystemRoot%\System32\SHELL32.dll, -16769'


### PR DESCRIPTION
way cleaner if its separate from the others and not in the middle of the S section
also the z kinda indicates that its something done by zoicware

<img width="624" height="712" alt="Screenshot 2026-09-07 024802" src="https://github.com/user-attachments/assets/26a0a261-379f-4b75-9a59-19e888417671" />
