### PR TITLE
add multiple new reg tweaks

### DIFF
--- a/registrytweaks.md
+++ b/registrytweaks.md
@@ -190,7 +190,6 @@
 - Disable Toggle Keys shortcut
 - Disable allow themes to change desktop icons
 - Disable automatically download maufacturers apps for devices
-- Disable automatic download of Narrator extensions
 - Disable auto read/scan in Ease of Access Center
 - Disable visual warning for Sound Sentry
 - Disable accessibility tool shortcut

--- a/registrytweaks.md
+++ b/registrytweaks.md
@@ -173,8 +173,6 @@
 - Increase wallpaper quality
 - Disable automatic troubleshooting
 - Disable write with fingertip
-- Disable share window from taskbar
-- Disable desktop preview
 - Disable small taskbar buttons
 - Disable touch keyboard
 - Disable auto correction

--- a/registrytweaks.md
+++ b/registrytweaks.md
@@ -193,3 +193,4 @@
 - Disable auto read/scan in Ease of Access Center
 - Disable visual warning for Sound Sentry
 - Disable accessibility tool shortcut
+- Disable share window from taskbar

--- a/registrytweaks.md
+++ b/registrytweaks.md
@@ -185,3 +185,12 @@
 - Enable last open window in taskbar
 - Hide removable drives from navigation pane
 - Minimize keyboard repeat delay
+- Disable show sync provider notifications
+- Disable use Sharing Wizard
+- Disable Toggle Keys shortcut
+- Disable allow themes to change desktop icons
+- Disable automatically download maufacturers apps for devices
+- Disable automatic download of Narrator extensions
+- Disable auto read/scan in Ease of Access Center
+- Disable visual warning for Sound Sentry
+- Disable accessibility tool shortcut

--- a/src/RegTweaks.txt
+++ b/src/RegTweaks.txt
@@ -785,6 +785,7 @@ Windows Registry Editor Version 5.00
 "WinEnterLaunchEnabled"=dword:00000000
 "ScriptingEnabled"=dword:00000000
 "OnlineServicesEnabled"=dword:00000000
+"CheckForScriptsEnabled"=dword:00000000
 
 [HKEY_CURRENT_USER\Software\Microsoft\Narrator]
 "NarratorCursorHighlight"=dword:00000000
@@ -1224,10 +1225,6 @@ Windows Registry Editor Version 5.00
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Device Metadata]
 "PreventDeviceMetadataFromNetwork"=dword:00000001
-
-; Disable automatic download of Narrator extensions
-[HKEY_CURRENT_USER\Software\Microsoft\Narrator\NoRoam]
-"CheckForScriptsEnabled"=dword:00000000
 
 ; Disable auto read/scan in Ease of Access Center
 [HKEY_CURRENT_USER\Software\Microsoft\Ease of Access]

--- a/src/RegTweaks.txt
+++ b/src/RegTweaks.txt
@@ -1238,3 +1238,7 @@ Windows Registry Editor Version 5.00
 ; Disable accessibility tool shortcut
 [HKEY_CURRENT_USER\Control Panel\Accessibility\SlateLaunch]
 "LaunchAT"=dword:00000000
+
+; Disable share window from taskbar
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
+"TaskbarSn"=dword:00000000

--- a/src/RegTweaks.txt
+++ b/src/RegTweaks.txt
@@ -1141,14 +1141,6 @@ Windows Registry Editor Version 5.00
 [HKEY_CURRENT_USER\Software\Microsoft\TabletTip\EmbeddedInkControl]
 "EnableInkingWithTouch"=dword:00000000
 
-; Disable share window from taskbar
-[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
-"TaskbarSn"=dword:00000000
-
-; Disable desktop preview
-[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
-"TaskbarSd"=dword:00000000
-
 ; Disable small taskbar buttons
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
 "IconSizePreference"=dword:00000001

--- a/src/RegTweaks.txt
+++ b/src/RegTweaks.txt
@@ -1201,3 +1201,43 @@ Windows Registry Editor Version 5.00
 ; Minimize keyboard repeat delay
 [HKEY_CURRENT_USER\Control Panel\Keyboard]
 "KeyboardDelay"="0"
+
+; Disable show sync provider notifications
+[HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
+"ShowSyncProviderNotifications"=dword:00000000
+
+; Disable use Sharing Wizard
+[HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
+"SharingWizardOn"=dword:00000000
+
+; Disable Toggle Keys shortcut
+[HKEY_CURRENT_USER\Control Panel\Accessibility\ToggleKeys]
+"Flags"="58"
+
+; Disable allow themes to change desktop icons
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes]
+"ThemeChangesDesktopIcons"=dword:00000000
+
+; Disable automatically download maufacturers apps for devices
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Device Metadata]
+"PreventDeviceMetadataFromNetwork"=dword:00000001
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Device Metadata]
+"PreventDeviceMetadataFromNetwork"=dword:00000001
+
+; Disable automatic download of Narrator extensions
+[HKEY_CURRENT_USER\Software\Microsoft\Narrator\NoRoam]
+"CheckForScriptsEnabled"=dword:00000000
+
+; Disable auto read/scan in Ease of Access Center
+[HKEY_CURRENT_USER\Software\Microsoft\Ease of Access]
+"selfscan"=dword:00000000
+"selfvoice"=dword:00000000
+
+; Disable visual warning for Sound Sentry
+[HKEY_CURRENT_USER\Control Panel\Accessibility\SoundSentry]
+"WindowsEffect"="0"
+
+; Disable accessibility tool shortcut
+[HKEY_CURRENT_USER\Control Panel\Accessibility\SlateLaunch]
+"LaunchAT"=dword:00000000

--- a/src/Restore.ps1
+++ b/src/Restore.ps1
@@ -2202,12 +2202,6 @@ Windows Registry Editor Version 5.00
 "EnableInkingWithTouch"=-
 
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
-"TaskbarSn"=-
-
-[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
-"TaskbarSd"=-
-
-[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
 "IconSizePreference"=-
 
 [HKEY_CURRENT_USER\Software\Microsoft\TabletTip\1.7]
@@ -2257,6 +2251,35 @@ Windows Registry Editor Version 5.00
 "MouseSpeed"="1"
 "MouseThreshold1"="6"
 "MouseThreshold2"="10"
+
+[HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
+"SharingWizardOn"=-
+"ShowSyncProviderNotifications"=-
+
+[HKEY_CURRENT_USER\Control Panel\Accessibility\ToggleKeys]
+"Flags"="62"
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes]
+"ThemeChangesDesktopIcons"=dword:00000001
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Device Metadata]
+"PreventDeviceMetadataFromNetwork"=dword:00000000
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Device Metadata]
+"PreventDeviceMetadataFromNetwork"=-
+
+[HKEY_CURRENT_USER\Software\Microsoft\Narrator\NoRoam]
+"CheckForScriptsEnabled"=-
+
+[HKEY_CURRENT_USER\Software\Microsoft\Ease of Access]
+"selfscan"=-
+"selfvoice"=-
+
+[HKEY_CURRENT_USER\Control Panel\Accessibility\SoundSentry]
+"WindowsEffect"="1"
+
+[HKEY_CURRENT_USER\Control Panel\Accessibility\SlateLaunch]
+"LaunchAT"=dword:00000001
 '@
 
         Add-Content -Path $file.FullName -Value $regContent -Force

--- a/src/Restore.ps1
+++ b/src/Restore.ps1
@@ -2278,6 +2278,9 @@ Windows Registry Editor Version 5.00
 
 [HKEY_CURRENT_USER\Control Panel\Accessibility\SlateLaunch]
 "LaunchAT"=dword:00000001
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced]
+"TaskbarSn"=-
 '@
 
         Add-Content -Path $file.FullName -Value $regContent -Force

--- a/src/Restore.ps1
+++ b/src/Restore.ps1
@@ -1921,6 +1921,7 @@ Windows Registry Editor Version 5.00
 "WinEnterLaunchEnabled"=-
 "ScriptingEnabled"=-
 "OnlineServicesEnabled"=-
+"CheckForScriptsEnabled"=-
 
 [HKEY_CURRENT_USER\Software\Microsoft\Ease of Access]
 "selfvoice"=-
@@ -2267,9 +2268,6 @@ Windows Registry Editor Version 5.00
 
 [HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Device Metadata]
 "PreventDeviceMetadataFromNetwork"=-
-
-[HKEY_CURRENT_USER\Software\Microsoft\Narrator\NoRoam]
-"CheckForScriptsEnabled"=-
 
 [HKEY_CURRENT_USER\Software\Microsoft\Ease of Access]
 "selfscan"=-


### PR DESCRIPTION
added and removed some reg tweaks

removed:
- Disable share window from taskbar
- Disable desktop preview

ppl seem to actually use these 
also fyi the share window from taskbar isnt a simple toggle anymore with the new taskbar customization it now has multiple options

added:
- Disable show sync provider notifications
- Disable use Sharing Wizard
- Disable Toggle Keys shortcut
- Disable allow themes to change desktop icons
- Disable automatically download maufacturers apps for devices
- Disable automatic download of Narrator extensions
- Disable auto read/scan in Ease of Access Center
- Disable visual warning for Sound Sentry
- Disable accessibility tool shortcut

was also gonna add this:

<img width="877" height="755" alt="image" src="https://github.com/user-attachments/assets/1c608803-76ce-4dfe-961d-e8b186b205b0" />

but the settings key alone isnt enough it needs the powercfg too which gets permission error when trying to do through reg

```reg
[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\VideoSettings]
"DisableHDROnBattery"=dword:00000000
```
```reg
[HKEY_LOCAL_MACHINE\System\ControlSet001\Control\Power\User\PowerSchemes\4f45f1be-5d65-4f93-9d0e-0b19e7babfb5\7516b95f-f776-4464-8c53-06167f40cc99\684c3e69-a4f7-4014-8754-d45179a56167]
"DCSettingIndex"=dword:00000001
```